### PR TITLE
enable DNS for bikeshed

### DIFF
--- a/config/vili/etc/dhcpd.conf
+++ b/config/vili/etc/dhcpd.conf
@@ -1,5 +1,5 @@
 option  domain-name "hq.thebikeshed.io";
-option  domain-name-servers 8.8.8.8, 8.8.4.4;
+option  domain-name-servers 172.16.8.1;
 
 subnet 10.255.0.0 netmask 255.255.255.0 {
     option routers 10.255.0.1;

--- a/config/vili/etc/rc.conf.local
+++ b/config/vili/etc/rc.conf.local
@@ -3,3 +3,5 @@ dhcpd_flags=
 isakmpd_flags="-K"
 ipsec=YES
 ospfd_flags=""
+unbound_flags=""
+nsd_flags=""

--- a/config/vili/var/nsd/etc/nsd.conf
+++ b/config/vili/var/nsd/etc/nsd.conf
@@ -1,0 +1,10 @@
+server:
+    hide-version: yes
+    ip-address: 127.0.0.1@8053
+
+remote-control:
+        control-enable: yes
+
+zone:
+    name: "hq.thebikeshed.io"
+    zonefile: "hq.thebikeshed.io"

--- a/config/vili/var/nsd/zones/hq.thebikeshed.io
+++ b/config/vili/var/nsd/zones/hq.thebikeshed.io
@@ -9,7 +9,6 @@ hq.thebikeshed.io. 3600 SOA ns1.hq.thebikeshed.io. admin.hq.thebikeshed.io. (
 
     IN NS ns1.hq.thebikeshed.io.
 
-# Client Network
 ns1             IN A 10.255.0.1
 frybook         IN A 10.255.0.2
 frybookair      IN A 10.255.0.3
@@ -41,7 +40,6 @@ hulk            IN A 10.255.0.231
 sobol           IN A 10.255.0.232
 vili            IN A 10.255.0.233
 
-# Server Network
 moe          IN A 10.255.2.51
 larry        IN A 10.255.2.52
 curly        IN A 10.255.2.53

--- a/config/vili/var/nsd/zones/hq.thebikeshed.io
+++ b/config/vili/var/nsd/zones/hq.thebikeshed.io
@@ -1,0 +1,60 @@
+$TTL 86400
+
+hq.thebikeshed.io. 3600 SOA ns1.hq.thebikeshed.io. admin.hq.thebikeshed.io. (
+    0001    ; serial
+    1800    ; refresh
+    7200    ; retry
+    1209600 ; expire
+    3600 )  ; negative
+
+    IN NS ns1.hq.thebikeshed.io.
+
+# Client Network
+ns1             IN A 10.255.0.1
+frybook         IN A 10.255.0.2
+frybookair      IN A 10.255.0.3
+pink            IN A 10.255.0.200
+grapple         IN A 10.255.0.201
+beryllium       IN A 10.255.0.202
+rigpa           IN A 10.255.0.203
+webpowerswitch  IN A 10.255.0.205
+tyr-tbolt       IN A 10.255.0.210
+rpi-office-01   IN A 10.255.0.212
+rpi-office-02   IN A 10.255.0.213
+digdug          IN A 10.255.0.214
+keg-right       IN A 10.255.0.215
+keg-left        IN A 10.255.0.216
+bigscreen       IN A 10.255.0.217
+door            IN A 10.255.0.218
+redrat          IN A 10.255.0.219
+pumpkin         IN A 10.255.0.220
+jenkins-osxmac  IN A 10.255.0.221
+tyr             IN A 10.255.0.222
+discmakers      IN A 10.255.0.223
+hue-bikeshed    IN A 10.255.0.224
+wrt54gl         IN A 10.255.0.225
+curly           IN A 10.255.0.226
+larry           IN A 10.255.0.227
+moe             IN A 10.255.0.228
+vera-lite       IN A 10.255.0.230
+hulk            IN A 10.255.0.231
+sobol           IN A 10.255.0.232
+vili            IN A 10.255.0.233
+
+# Server Network
+moe          IN A 10.255.2.51
+larry        IN A 10.255.2.52
+curly        IN A 10.255.2.53
+webpwr02     IN A 10.255.2.54
+webpwr03     IN A 10.255.2.55
+ares         IN A 10.255.2.56
+amtren-lower IN A 10.255.2.57
+tolstoy      IN A 10.255.2.58
+esx03        IN A 10.255.2.197
+esx01        IN A 10.255.2.198
+esx02        IN A 10.255.2.199
+sol          IN A 10.255.2.200
+feynman      IN A 10.255.2.241
+saturn       IN A 10.255.2.242
+planck       IN A 10.255.2.244
+newton       IN A 10.255.2.251

--- a/config/vili/var/unbound/etc/named.cache
+++ b/config/vili/var/unbound/etc/named.cache
@@ -1,0 +1,90 @@
+;       This file holds the information on root name servers needed to
+;       initialize cache of Internet domain name servers
+;       (e.g. reference this file in the "cache  .  <file>"
+;       configuration file of BIND domain name servers).
+;
+;       This file is made available by InterNIC 
+;       under anonymous FTP as
+;           file                /domain/named.cache
+;           on server           FTP.INTERNIC.NET
+;       -OR-                    RS.INTERNIC.NET
+;
+;       last update:    May 23, 2015
+;       related version of root zone:   2015052300
+;
+; formerly NS.INTERNIC.NET
+;
+.                        3600000      NS    A.ROOT-SERVERS.NET.
+A.ROOT-SERVERS.NET.      3600000      A     198.41.0.4
+A.ROOT-SERVERS.NET.      3600000      AAAA  2001:503:ba3e::2:30
+;
+; FORMERLY NS1.ISI.EDU
+;
+.                        3600000      NS    B.ROOT-SERVERS.NET.
+B.ROOT-SERVERS.NET.      3600000      A     192.228.79.201
+B.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:84::b
+;
+; FORMERLY C.PSI.NET
+;
+.                        3600000      NS    C.ROOT-SERVERS.NET.
+C.ROOT-SERVERS.NET.      3600000      A     192.33.4.12
+C.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:2::c
+;
+; FORMERLY TERP.UMD.EDU
+;
+.                        3600000      NS    D.ROOT-SERVERS.NET.
+D.ROOT-SERVERS.NET.      3600000      A     199.7.91.13
+D.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:2d::d
+;
+; FORMERLY NS.NASA.GOV
+;
+.                        3600000      NS    E.ROOT-SERVERS.NET.
+E.ROOT-SERVERS.NET.      3600000      A     192.203.230.10
+;
+; FORMERLY NS.ISC.ORG
+;
+.                        3600000      NS    F.ROOT-SERVERS.NET.
+F.ROOT-SERVERS.NET.      3600000      A     192.5.5.241
+F.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:2f::f
+;
+; FORMERLY NS.NIC.DDN.MIL
+;
+.                        3600000      NS    G.ROOT-SERVERS.NET.
+G.ROOT-SERVERS.NET.      3600000      A     192.112.36.4
+;
+; FORMERLY AOS.ARL.ARMY.MIL
+;
+.                        3600000      NS    H.ROOT-SERVERS.NET.
+H.ROOT-SERVERS.NET.      3600000      A     128.63.2.53
+H.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:1::803f:235
+;
+; FORMERLY NIC.NORDU.NET
+;
+.                        3600000      NS    I.ROOT-SERVERS.NET.
+I.ROOT-SERVERS.NET.      3600000      A     192.36.148.17
+I.ROOT-SERVERS.NET.      3600000      AAAA  2001:7fe::53
+;
+; OPERATED BY VERISIGN, INC.
+;
+.                        3600000      NS    J.ROOT-SERVERS.NET.
+J.ROOT-SERVERS.NET.      3600000      A     192.58.128.30
+J.ROOT-SERVERS.NET.      3600000      AAAA  2001:503:c27::2:30
+;
+; OPERATED BY RIPE NCC
+;
+.                        3600000      NS    K.ROOT-SERVERS.NET.
+K.ROOT-SERVERS.NET.      3600000      A     193.0.14.129
+K.ROOT-SERVERS.NET.      3600000      AAAA  2001:7fd::1
+;
+; OPERATED BY ICANN
+;
+.                        3600000      NS    L.ROOT-SERVERS.NET.
+L.ROOT-SERVERS.NET.      3600000      A     199.7.83.42
+L.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:3::42
+;
+; OPERATED BY WIDE
+;
+.                        3600000      NS    M.ROOT-SERVERS.NET.
+M.ROOT-SERVERS.NET.      3600000      A     202.12.27.33
+M.ROOT-SERVERS.NET.      3600000      AAAA  2001:dc3::35
+; End of file

--- a/config/vili/var/unbound/etc/unbound.conf
+++ b/config/vili/var/unbound/etc/unbound.conf
@@ -1,0 +1,28 @@
+# cat unbound.conf
+# $OpenBSD: unbound.conf,v 1.4 2014/04/02 21:43:30 millert Exp $
+
+server:
+    interface: 0.0.0.0
+    do-not-query-localhost: no
+
+    access-control: 0.0.0.0/0 refuse
+    access-control: 127.0.0.0/8 allow
+    access-control: 10.0.0.0/8 allow
+
+    hide-identity: yes
+    hide-version: yes
+
+    root-hints: "/var/unbound/etc/named.cache"
+    auto-trust-anchor-file: "/var/unbound/db/root.key"
+
+remote-control:
+    control-enable: yes
+    control-interface: 127.0.0.1
+
+stub-zone:
+    name: "hq.thebikeshed.io"
+    stub-addr: 127.0.0.1@8053
+
+stub-zone:
+    name: "hq.fryman.io"
+    stub-addr: 10.255.4.4@8053


### PR DESCRIPTION
Yet another "first :hammer:" solution.

This PR adds the basics of `nsd`/`unbound` to `vili`, and sets up something for us to use as we work on second and other hammers.