### PR TITLE
change DHCP option for DNS server to be 10.255.7.1

### DIFF
--- a/config/vili/etc/openvpn/openvpn.conf
+++ b/config/vili/etc/openvpn/openvpn.conf
@@ -14,7 +14,7 @@ push route 10.255.2.0 255.255.255.0
 push route 10.255.0.0 255.255.255.0
 
 topology subnet
-push "dhcp-option DNS 10.255.0.1"
+push "dhcp-option DNS 10.255.7.1"
 push "dhcp-option DOMAIN hq.thebikeshed.io thebikeshed.io"
 
 keepalive 10 120


### PR DESCRIPTION
DNS requests issued against 10.255.0.1 would be returned via 10.255.7.1 because the DNS server sees the target as available via a local, non-routed network.  This changes the openVPN configuration to hand out the local '.1' address for DNS on the VPN client network.