### PR TITLE
Controll TV/Media Stuffs via API

### DIFF
--- a/config/openhab/items/devices.items
+++ b/config/openhab/items/devices.items
@@ -1,3 +1,8 @@
+// Referenced via HTTP as such:
+//
+// http://10.255.0.217:9090/CMD?HarmonyHubWatchTV=ON
+// http://10.255.0.217:9090/CMD?HarmonyHubPowerOff=OFF
+
 // Logitech Harmony Hub
 String HarmonyHubActivity          "activity [%s]"    { harmonyhub="*[currentActivity]" }
 String HarmonyHubPowerOff          "powerOff"         { harmonyhub=">[start:PowerOff]" }

--- a/config/openhab/items/devices.items
+++ b/config/openhab/items/devices.items
@@ -1,0 +1,10 @@
+// Logitech Harmony Hub
+String HarmonyHubActivity          "activity [%s]"    { harmonyhub="*[currentActivity]" }
+String HarmonyHubPowerOff          "powerOff"         { harmonyhub=">[start:PowerOff]" }
+String HarmonyHubMute              "mute"             { harmonyhub=">[press:Panasonic TV:Mute]" }
+String HarmonyHubWatchTV           "watchAppleTV"     { harmonyhub=">[start:AppleTV]" }
+String HarmonyHubWatchChromecast   "watchChromecast"  { harmonyhub=">[start:Chromecast]" }
+String HarmonyHubWatchFireStick    "watchFireStick"   { harmonyhub=">[start:FireStick]" }
+String HarmonyHubWatchDashboard    "watchDashboard"   { harmonyhub=">[start:Dashboard]" }
+String HarmonyHubWatchPS3          "watchPS3"         { harmonyhub=">[start:PS3]" }
+String HarmonyHubWatchXBoxOne      "watchXBox"        { harmonyhub=">[start:XBox One]" }

--- a/config/openhab/openhab.cfg
+++ b/config/openhab/openhab.cfg
@@ -1,0 +1,3 @@
+harmonyhub:host=10.255.0.171
+harmonyhub:username=crunchy@websages.org
+harmonyhub:password=!4u2kn0w!


### PR DESCRIPTION
Here we gooo!!!

This PR introduces a very basic OpenHAB setup, which is running on one of the RPIs (TV Camera). Nothing major, but will get us going.

Controls inputs using Harmony Hub and new Monoprice Media Switcher as well.

Needs auth, and a few other things... 

Oh, and don't forget this... bitches...

```
harmony_send_code() {
    ACTION=$1
    CMD=$2
    
    ## For OpenHAB
    IP=10.255.0.217
    PORT=9090
    URL="http://${IP}:${PORT}/CMD?${ACTION}=${CMD}"
    curl -s $URL
}

alias tv_poweroff='harmony_send_code HarmonyHubPowerOff OFF'
alias tv_mute='harmony_send_code HarmonyHubMute ON'  # Mute and unmute
alias tv_appletv='harmony_send_code HarmonyHubWatchTV ON'
alias tv_chromecast='harmony_send_code HarmonyHubWatchChromecast ON'
alias tv_firestick='harmony_send_code HarmonyHubWatchFireStick ON'
alias tv_dashboard='harmony_send_code HarmonyHubWatchDashboard ON'
alias tv_ps3='harmony_send_code HarmonyHubWatchPS3 ON'
alias tv_xbone='harmony_send_code HarmonyHubWatchXBoxOne ON'
alias onscreen='tv_appletv'
```

