### PR TITLE
split-horizon DNS [thebikeshed.io]

### DIFF
--- a/config/planck/etc/haproxy/haproxy.cfg
+++ b/config/planck/etc/haproxy/haproxy.cfg
@@ -124,7 +124,7 @@ backend octoprint
   mode http
 
   balance roundrobin
-  server sobol 10.255.0.232:443 check ssl verify none
+  server octoprint 10.255.0.201:5000 check verify none
 
 backend dashboard
   mode http

--- a/config/vili/var/nsd/etc/nsd.conf
+++ b/config/vili/var/nsd/etc/nsd.conf
@@ -6,5 +6,9 @@ remote-control:
         control-enable: yes
 
 zone:
+    name: "thebikeshed.io"
+    zonefile: "thebikeshed.io"
+
+zone:
     name: "hq.thebikeshed.io"
     zonefile: "hq.thebikeshed.io"

--- a/config/vili/var/nsd/zones/thebikeshed.io
+++ b/config/vili/var/nsd/zones/thebikeshed.io
@@ -1,0 +1,15 @@
+$TTL 86400
+
+thebikeshed.io. 3600 SOA ns1.thebikeshed.io. admin.thebikeshed.io. (
+    0001    ; serial
+    1800    ; refresh
+    7200    ; retry
+    1209600 ; expire
+    3600 )  ; negative
+
+    IN NS ns1.thebikeshed.io.
+
+ns1             IN A 10.255.0.1
+planck          IN A 10.255.2.244
+octoprint       IN CNAME planck
+puppycam        IN CNAME planck

--- a/config/vili/var/unbound/etc/unbound.conf
+++ b/config/vili/var/unbound/etc/unbound.conf
@@ -20,6 +20,10 @@ remote-control:
     control-interface: 127.0.0.1
 
 stub-zone:
+    name: "thebikeshed.io"
+    stub-addr: 127.0.0.1@8053
+
+stub-zone:
     name: "hq.thebikeshed.io"
     stub-addr: 127.0.0.1@8053
 


### PR DESCRIPTION
This PR adds the 1st-:hammer: of split-dns inside the bikeshed.io.

puppycam and octoprint work internally now.
