### PR TITLE
Moving DNS Services

### DIFF
--- a/config/nodes/vili.hq.thebikeshed.io/etc/dhcpd.conf
+++ b/config/nodes/vili.hq.thebikeshed.io/etc/dhcpd.conf
@@ -2,7 +2,7 @@ option  domain-name "hq.thebikeshed.io";
 
 subnet 10.255.0.0 netmask 255.255.255.0 {
     option routers 10.255.0.1;
-    option  domain-name-servers 10.255.0.1;
+    option  domain-name-servers 10.255.12.57;
     # option domain-search "bna.github.net", "bike.fryman.io";
     range 10.255.0.100 10.255.0.199;
     default-lease-time 600;
@@ -42,7 +42,7 @@ subnet 10.255.0.0 netmask 255.255.255.0 {
 
 subnet 10.255.1.0 netmask 255.255.255.0 {
     option routers 10.255.1.1;
-    option  domain-name-servers 10.255.1.1;
+    option  domain-name-servers 10.255.12.57;
     range 10.255.1.100 10.255.1.199;
     default-lease-time 600;
     max-lease-time 7200;
@@ -53,7 +53,7 @@ subnet 10.255.1.0 netmask 255.255.255.0 {
 
 subnet 10.255.2.0 netmask 255.255.255.0 {
     option routers 10.255.2.1;
-    option  domain-name-servers 10.255.2.1;
+    option  domain-name-servers 10.255.12.57;
     range 10.255.2.2 10.255.2.50;
     default-lease-time 600;
     max-lease-time 7200;
@@ -69,7 +69,7 @@ subnet 10.255.2.0 netmask 255.255.255.0 {
 
 subnet 10.255.4.0 netmask 255.255.255.0 {
     option routers 10.255.4.1;
-    option  domain-name-servers 10.255.4.1;
+    option  domain-name-servers 10.255.12.57;
     range 10.255.4.100 10.255.4.200;
     default-lease-time 600;
     max-lease-time 7200;
@@ -79,7 +79,7 @@ subnet 10.255.4.0 netmask 255.255.255.0 {
 
 subnet 10.255.9.0 netmask 255.255.255.0 {
     option routers 10.255.9.1;
-    option  domain-name-servers 10.255.9.1;
+    option  domain-name-servers 10.255.12.57;
     range 10.255.9.2 10.255.9.50;
     default-lease-time 600;
     max-lease-time 7200;
@@ -88,7 +88,7 @@ subnet 10.255.9.0 netmask 255.255.255.0 {
 
 subnet 10.255.10.0 netmask 255.255.255.0 {
     option routers 10.255.10.1;
-    option  domain-name-servers 10.255.10.1;
+    option  domain-name-servers 10.255.12.57;
     range 10.255.10.2 10.255.10.50;
     default-lease-time 600;
     max-lease-time 7200;
@@ -96,7 +96,7 @@ subnet 10.255.10.0 netmask 255.255.255.0 {
 
 subnet 10.255.12.0 netmask 255.255.255.0 {
     option routers 10.255.12.1;
-    option  domain-name-servers 10.255.12.1;
+    option  domain-name-servers 10.255.12.57;
     range 10.255.12.2 10.255.12.50;
     default-lease-time 600;
     max-lease-time 7200;
@@ -115,7 +115,7 @@ subnet 10.255.12.0 netmask 255.255.255.0 {
 
 subnet 10.255.13.0 netmask 255.255.255.0 {
     option routers 10.255.13.1;
-    option  domain-name-servers 10.255.13.1;
+    option  domain-name-servers 10.255.12.57;
     range 10.255.13.2 10.255.13.50;
     default-lease-time 600;
     max-lease-time 7200;
@@ -127,7 +127,7 @@ subnet 10.255.13.0 netmask 255.255.255.0 {
 
 subnet 10.255.17.0 netmask 255.255.255.0 {
     option routers 10.255.17.1;
-    option  domain-name-servers 10.255.17.1;
+    option  domain-name-servers 10.255.12.57;
     range 10.255.17.10 10.255.17.50;
     default-lease-time 600;
     max-lease-time 7200;

--- a/config/nodes/vili.hq.thebikeshed.io/etc/openvpn/openvpn.conf
+++ b/config/nodes/vili.hq.thebikeshed.io/etc/openvpn/openvpn.conf
@@ -15,7 +15,7 @@ push route 10.255.0.0 255.255.255.0
 push route 10.255.12.0 255.255.255.0
 
 topology subnet
-push "dhcp-option DNS 10.255.7.1"
+push "dhcp-option DNS 10.255.12.57"
 push "dhcp-option DOMAIN hq.thebikeshed.io thebikeshed.io"
 
 


### PR DESCRIPTION
Moving DNS Services from the NSD/Unbound setup on vili.hq.thebikeshed.io to faraday.hq.thebikeshed.io.  This is a first :hammer: to getting to LDAP backed DNS and a resolution to janky internal DNS resolution.